### PR TITLE
Add broccoli-cli as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
+    "broccoli-cli": "^1.0.0",
     "glimmer-build": "^0.1.2",
     "glimmer-engine": "^0.18.1"
   }


### PR DESCRIPTION
This is so `npm test` will still pass even if broccoli-cli is not installed globally.