### PR TITLE
Bump @glimmer/build to 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "glimmer-engine": "^0.18.1",
-    "testem": "^1.13.0",
-    "typescript": "^2.1.5"
+    "testem": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "glimmer-util": "^0.5.3"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.1.7",
+    "@glimmer/build": "^0.1.9",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "glimmer-engine": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   ],
   "repository": "https://github.com/glimmerjs/glimmer-di",
   "license": "MIT",
-  "main": "dist/glimmer-di/index.js",
-  "typings": "dist/glimmer-di/index.d.ts",
+  "main": "dist/commonjs/es2017/index.js",
+  "module": "dist/modules/es2017/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",
     "build:tests": "rm -rf tests && BROCCOLI_ENV=tests broccoli build tests",

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -14,6 +14,6 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    "node_modules/@types/**"
+    "node_modules/@types/**/*.ts"
   ]
 }


### PR DESCRIPTION
* `dist/types` is now output in builds
* `main`, `module`, and `types` can be properly set in package.json
* direct devdep of typescript should no longer be needed, now that @glimmer/build is properly using `findLib`