### PR TITLE
Use absolute paths in Brocfile

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,7 +1,10 @@
 const build = require('@glimmer/build');
+const path = require('path');
+
+const glimmerEnginePath = path.dirname(require.resolve('glimmer-engine/package'));
 
 module.exports = build({
   testDependencies: [
-    'node_modules/glimmer-engine/dist/amd/glimmer-common.amd.js'
+    path.join(glimmerEnginePath, 'dist/amd/glimmer-common.amd.js')
   ]
 });


### PR DESCRIPTION
Corresponds to [#16](https://github.com/glimmerjs/glimmer-build/pull/16) in `@glimmer/build`. This should be merged right after that is merged and a new release is cut otherwise the build will be broken.