### PR TITLE
Bump @glimmer/util and @glimmer/build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 
 node_js:
-  - "4"
   - "6"
   - "node"
 

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,10 +1,14 @@
+"use strict";
+
 const build = require('@glimmer/build');
-const path = require('path');
+const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
 
-const glimmerEnginePath = path.dirname(require.resolve('glimmer-engine/package'));
+let buildOptions = {};
 
-module.exports = build({
-  testDependencies: [
-    path.join(glimmerEnginePath, 'dist/amd/glimmer-common.amd.js')
-  ]
-});
+if (process.env.BROCCOLI_ENV === 'tests') {
+  buildOptions.vendorTrees = [
+    buildVendorPackage('@glimmer/util')
+  ];
+}
+
+module.exports = build(buildOptions);

--- a/package.json
+++ b/package.json
@@ -21,10 +21,9 @@
     "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.1.10",
+    "@glimmer/build": "^0.2.0",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
-    "glimmer-engine": "^0.18.1",
     "testem": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "glimmer-util": "^0.5.3"
+    "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {
     "@glimmer/build": "^0.1.10",

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,7 +1,7 @@
 import { Factory } from './factory';
 import Registry, { Injection } from './registry';
 import { Resolver } from './resolver';
-import { dict, Dict } from 'glimmer-util';
+import { dict, Dict } from '@glimmer/util';
 
 export default class Container {
   private _registry: Registry;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import { dict, Dict } from 'glimmer-util';
+import { dict, Dict } from '@glimmer/util';
 import { Factory } from './factory';
 
 export interface RegistrationOptions {
@@ -92,5 +92,5 @@ export default class Registry {
     Array.prototype.push.apply(injections, this._registeredInjections[type]);
     Array.prototype.push.apply(injections, this._registeredInjections[specifier]);
     return injections;
-  }  
+  }
 }


### PR DESCRIPTION
Use new `vendorTrees` option in `@glimmer/build` to build `@glimmer/util` for testing. This eliminates the need for the redundant `glimmer-engine` dependency.

[Closes #1]
