### PR TITLE
Require identify method on Owner interface

### DIFF
--- a/src/owner.ts
+++ b/src/owner.ts
@@ -13,6 +13,9 @@ export function setOwner(object: Object, owner: Owner): void {
 }
 
 export interface Owner {
+  identify(specifier: string, referrer?: string): string;
+
   factoryFor(specifier: string, referrer?: string): Factory<any>;
+  
   lookup(specifier: string, referrer?: string): any;
 }

--- a/test/owner-test.ts
+++ b/test/owner-test.ts
@@ -6,6 +6,8 @@ const { module, test } = QUnit;
 module('Owner');
 
 class Application implements Owner {
+  identify(specifier: string, referrer?: string): string {}
+
   factoryFor(specifier: string, referrer?: string): Factory<any> {
     return {
       create(injections?: Object) {


### PR DESCRIPTION
The `identify` method is useful for converting an identifier to an
absolute identifier. Most implementations will probably proxy to a
Resolver’s `identify` method.