### PR TITLE
Introduce RegistryReader, RegistryWriter, and RegistryAccessor interfaces

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -1,15 +1,15 @@
 import { Factory } from './factory';
-import Registry, { Injection } from './registry';
+import { RegistryReader, Injection } from './registry';
 import { Resolver } from './resolver';
 import { dict, Dict } from '@glimmer/util';
 
 export default class Container {
-  private _registry: Registry;
+  private _registry: RegistryReader;
   private _resolver: Resolver;
   private _lookups: Dict<any>;
   private _factoryLookups: Dict<any>;
 
-  constructor(registry: Registry, resolver: Resolver = null) {
+  constructor(registry: RegistryReader, resolver: Resolver = null) {
     this._registry = registry;
     this._resolver = resolver;
     this._lookups = dict<any>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 export { default as Container } from './container';
 export { Factory } from './factory';
-export { default as Registry, Injection, RegistrationOptions } from './registry';
+export { 
+  RegistryReader,
+  RegistryWriter,
+  RegistryAccessor,
+  default as Registry, 
+  Injection, 
+  RegistrationOptions 
+} from './registry';
 export { Resolver } from './resolver';
 export { Owner, getOwner, setOwner, OWNER } from './owner';
 export {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,7 +11,24 @@ export interface Injection {
   source: string
 }
 
-export default class Registry {
+export interface RegistryWriter {
+  register(specifier: string, factory: any, options?: RegistrationOptions): void;
+  unregister(specifier: string): void;
+  registerOption(specifier: string, option: string, value: any): void;
+  unregisterOption(specifier: string, option: string): void;
+  registerInjection(specifier: string, property: string, source: string): void;
+}
+
+export interface RegistryReader {
+  registration(specifier: string): any;
+  registeredOption(specifier: string, option: string): any;
+  registeredOptions(specifier: string): any;
+  registeredInjections(specifier: string): Injection[];
+}
+
+export interface RegistryAccessor extends RegistryReader, RegistryWriter {}
+
+export default class Registry implements RegistryAccessor {
   private _registrations: Dict<Factory<any>>;
   private _registeredOptions: Dict<any>;
   private _registeredInjections: Dict<Injection[]>;


### PR DESCRIPTION
These interfaces allow for more fine-tuned control over access to a 
registry.

The Container only needs to read from a registry, so it can make do with
a RegistryReader.

Applications may only want to allow full access to a registry during
an initialization period, during which they expose a registry through
a RegistryAccessor.

These interfaces also provide the opportunity to normalize input, such
as specifiers, in a class that proxies to an underlying Registry.