### PR TITLE
`factoryFor` injections

### DIFF
--- a/src/factory-definition.ts
+++ b/src/factory-definition.ts
@@ -1,0 +1,3 @@
+export interface FactoryDefinition<T> {
+  create(injections?: Object): T;
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,3 +1,6 @@
+import { FactoryDefinition } from './factory-definition';
+
 export interface Factory<T> {
+  class: FactoryDefinition<T>;
   create(injections?: Object): T;
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,6 @@
 import { dict, Dict } from '@glimmer/util';
 import { Factory } from './factory';
+import { FactoryDefinition } from './factory-definition';
 
 export interface RegistrationOptions {
   singleton?: boolean;
@@ -29,24 +30,24 @@ export interface RegistryReader {
 export interface RegistryAccessor extends RegistryReader, RegistryWriter {}
 
 export default class Registry implements RegistryAccessor {
-  private _registrations: Dict<Factory<any>>;
+  private _registrations: Dict<FactoryDefinition<any>>;
   private _registeredOptions: Dict<any>;
   private _registeredInjections: Dict<Injection[]>;
 
   constructor() {
-    this._registrations = dict<any>();
+    this._registrations = dict<FactoryDefinition<any>>();
     this._registeredOptions = dict<any>();
     this._registeredInjections = dict<Injection[]>();
   }
 
-  register(specifier: string, factory: any, options?: RegistrationOptions): void {
-    this._registrations[specifier] = factory;
+  register(specifier: string, factoryDefinition: FactoryDefinition<any>, options?: RegistrationOptions): void {
+    this._registrations[specifier] = factoryDefinition;
     if (options) {
       this._registeredOptions[specifier] = options;
     }
   }
 
-  registration(specifier: string): any {
+  registration(specifier: string): FactoryDefinition<any> {
     return this._registrations[specifier];
   }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,5 +1,7 @@
+import { FactoryDefinition } from './factory-definition';
+
 export interface Resolver {
   identify(specifier: string, referrer?: string): string;
 
-  retrieve(specifier: string): any;
+  retrieve(specifier: string): FactoryDefinition<any>;
 }


### PR DESCRIPTION
This implements the `factoryFor` interface specified in https://github.com/emberjs/rfcs/blob/master/text/0150-factory-for.md and introduces concept of `Creator` (which is distinct from `Factory`). One registers Creators and retrieves Factories. 