### PR TITLE
Remove @glimmer/util dependency

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -5,10 +5,4 @@ const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
 
 let buildOptions = {};
 
-if (process.env.BROCCOLI_ENV === 'tests') {
-  buildOptions.vendorTrees = [
-    buildVendorPackage('@glimmer/util', { external: ['babel-helpers'] }),
-  ];
-}
-
 module.exports = build(buildOptions);

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "preversion": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",
     "test": "testem ci"
   },
-  "dependencies": {
-    "@glimmer/util": "^0.21.0"
-  },
   "devDependencies": {
     "@glimmer/build": "^0.2.1",
     "broccoli": "^1.1.0",

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,7 +1,7 @@
 import { Factory, FactoryDefinition } from './factory';
 import { RegistryReader, Injection } from './registry';
 import { Resolver } from './resolver';
-import { dict, Dict } from '@glimmer/util';
+import { Dict } from './dict';
 
 export default class Container {
   private _registry: RegistryReader;
@@ -12,8 +12,8 @@ export default class Container {
   constructor(registry: RegistryReader, resolver: Resolver = null) {
     this._registry = registry;
     this._resolver = resolver;
-    this._lookups = dict<any>();
-    this._factoryDefinitionLookups = dict<FactoryDefinition<any>>();
+    this._lookups = {};
+    this._factoryDefinitionLookups = {};
   }
 
   factoryFor(specifier: string): Factory<any> {

--- a/src/dict.d.ts
+++ b/src/dict.d.ts
@@ -1,0 +1,3 @@
+export interface Dict<T> {
+  [index: string]: T;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Container } from './container';
+export * from './dict';
 export * from './factory';
 export { 
   RegistryReader,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import { dict, Dict } from '@glimmer/util';
+import { Dict } from './dict';
 import { Factory, FactoryDefinition } from './factory';
 
 export interface RegistrationOptions {
@@ -34,9 +34,9 @@ export default class Registry implements RegistryAccessor {
   private _registeredInjections: Dict<Injection[]>;
 
   constructor() {
-    this._registrations = dict<FactoryDefinition<any>>();
-    this._registeredOptions = dict<any>();
-    this._registeredInjections = dict<Injection[]>();
+    this._registrations = {};
+    this._registeredOptions = {};
+    this._registeredInjections = {};
   }
 
   register(specifier: string, factoryDefinition: FactoryDefinition<any>, options?: RegistrationOptions): void {


### PR DESCRIPTION
The sole reason for this dependency was to import the `Dict` interface,
which is so simple that it can be repeated here with little/no cost.
Removing this dependency should make @glimmer/di more usable as an 
independent library.

Furthermore, removing this dependency also fixes this TSC compiler issue:
https://github.com/glimmerjs/glimmer-build/issues/23