### PR TITLE
Add tests and implement fallback for options and injections

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -80,11 +80,18 @@ export default class Registry implements RegistryAccessor {
   }
 
   registeredOption(specifier: string, option: string): any {
+    let result: Boolean;
     let options = this.registeredOptions(specifier);
 
     if (options) {
-      return options[option];
+      result = options[option];
     }
+
+    if (result === undefined && this._fallback !== undefined) {
+      result = this._fallback.registeredOption(specifier, option);
+    }
+
+    return result;
   }
 
   registeredOptions(specifier: string): any {
@@ -117,7 +124,7 @@ export default class Registry implements RegistryAccessor {
 
   registeredInjections(specifier: string): Injection[] {
     let [type] = specifier.split(':');
-    let injections: Injection[] = [];
+    let injections: Injection[] = this._fallback ? this._fallback.registeredInjections(specifier) : [];
     Array.prototype.push.apply(injections, this._registeredInjections[type]);
     Array.prototype.push.apply(injections, this._registeredInjections[specifier]);
     return injections;

--- a/test/container-test.ts
+++ b/test/container-test.ts
@@ -45,6 +45,27 @@ test('#factoryFor - returns an object that creates the registered class with inj
   assert.equal(fooInstance.widget, 'widget', 'dependencies are injected');
 });
 
+test('#factoryFor - returns an object that creates the registered class with injections from fallback registry', function(assert) {
+  class Foo {
+    static create(options: Object) { return new this(options); }
+    constructor(options: Object) { Object.assign(this, options); }
+  }
+
+  let baseRegistry = new Registry();
+  let chainedRegistry = new Registry({ fallback: baseRegistry });
+  let container = new Container(chainedRegistry);
+  let fooInstance;
+
+  chainedRegistry.register('thing:foo', Foo);
+  baseRegistry.register('widget:main', 'widget');
+  baseRegistry.registerInjection('thing', 'widget', 'widget:main');
+  baseRegistry.registerOption('widget:main', 'instantiate', false);
+
+  fooInstance = container.factoryFor('thing:foo').create();
+
+  assert.equal(fooInstance.widget, 'widget', 'dependencies are injected');
+});
+
 test('#factoryFor - returns an object that creates the registered class with give properties', function(assert) {
   class Foo {
     static create(options: Object) { return new this(options); }

--- a/test/registry-test.ts
+++ b/test/registry-test.ts
@@ -92,6 +92,25 @@ test('#registerOption, #registeredOptions, #registeredOption, #unregisterOption'
   assert.strictEqual(registry.registeredOption('foo:bar', 'singleton'), undefined);
 });
 
+test('#registeredOption fallback', function(assert) {
+  let baseRegistry = new Registry();
+  let chainedRegistry = new Registry({fallback: baseRegistry});
+
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), undefined);
+
+  baseRegistry.registerOption('foo:bar', 'singleton', true);
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), true);
+
+  chainedRegistry.registerOption('foo:bar', 'singleton', false);
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), false);
+
+  chainedRegistry.unregisterOption('foo:bar', 'singleton');
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), true);
+
+  baseRegistry.unregisterOption('foo:bar', 'singleton');
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), undefined);
+});
+
 test('Options registered by full name supercede those registered by type', function(assert) {
   class Foo {
     static create() { return { foo: 'bar' }; }
@@ -105,4 +124,14 @@ test('Options registered by full name supercede those registered by type', funct
   assert.strictEqual(registry.registeredOption('foo:bar', 'singleton'), false);
   registry.registerOption('foo:bar', 'singleton', true);
   assert.strictEqual(registry.registeredOption('foo:bar', 'singleton'), true);
+});
+
+test('Options registered by type on chained registry supercede those by type on the base', function(assert) {
+  let baseRegistry = new Registry();
+  let chainedRegistry = new Registry({fallback: baseRegistry});
+
+  baseRegistry.registerOption('foo:bar', 'singleton', true);
+  chainedRegistry.registerOption('foo', 'singleton', false);
+
+  assert.strictEqual(chainedRegistry.registeredOption('foo:bar', 'singleton'), false);
 });


### PR DESCRIPTION
While integrating with Ember it quickly became clear the fallback semantics of https://github.com/glimmerjs/glimmer-di/pull/34 were vastly under-powered.

Options and injections from a fallback registry must also be applied to an instantiation.

@dgeb It seems like two other directions to go would be to create a `FallbackableRegistry` that wraps registries and only manages the fallback part of the work. I'm not sure there is a lot of value in that.

Oddest thing about this change is that while `registrationOption` will return the singleton state taking the fallback into consideration, the `registrationOptions` API will not. The latter (and `registrationInjections` which is also make fallback compatible) are both used in Ember tests, but not on any public APIs. Perhaps we can just not expose some of this, and keep all APIs fallback safe.