### PR TITLE
Add teardown APIs

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,8 +1,10 @@
 export interface FactoryDefinition<T> {
   create(injections?: Object): T;
+  teardown?(instance: Object): void;
 }
 
 export interface Factory<T> {
   class: FactoryDefinition<T>;
   create(injections?: Object): T;
+  teardown(instance: any): void;
 }


### PR DESCRIPTION
The container is responsible for instance lifetimes, and as such must have a way to teardown instances when they are no longer valid. This commit adds the following API:

* `teardown` as a method on container instances. When called, all singleton instances cached on the container are run through their own teardown logic.
* `defaultTeardown` as a hook on the container (akin to `defaultInjections`). Defines default teardown logic for teardown, and is a noop by default.
* `teardown` as a property of `FactoryDefinition` objects. This is how a registered factory provides its own teardown logic.
* `teardown` as a property of `Factory` objects. An instance created by something other than the container can be passed to this function to be torn down.

See the included tests for example usage.