### PR TITLE
Convert usages of `Object` type to `object`

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -71,7 +71,7 @@ export default class Container {
     return instance;
   }
 
-  defaultInjections(specifier: string): Object {
+  defaultInjections(specifier: string): object {
     return {};
   }
 
@@ -88,7 +88,7 @@ export default class Container {
   defaultTeardown(instance): void {
   }
 
-  private buildInjections(specifier: string): Object {
+  private buildInjections(specifier: string): object {
     let hash = this.defaultInjections(specifier);
     let injections: Injection[] = this._registry.registeredInjections(specifier);
     let injection: Injection;

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,10 +1,10 @@
 export interface FactoryDefinition<T> {
-  create(injections?: Object): T;
-  teardown?(instance: Object): void;
+  create(injections?: object): T;
+  teardown?(instance: object): void;
 }
 
 export interface Factory<T> {
   class: FactoryDefinition<T>;
-  create(injections?: Object): T;
+  create(injections?: object): T;
   teardown(instance: any): void;
 }

--- a/src/owner.ts
+++ b/src/owner.ts
@@ -4,11 +4,11 @@ import { Factory } from './factory';
 // TODO - use symbol
 export const OWNER = '__owner__';
 
-export function getOwner(object: Object): Owner {
+export function getOwner(object: object): Owner {
   return object[OWNER];
 }
 
-export function setOwner(object: Object, owner: Owner): void {
+export function setOwner(object: object, owner: Owner): void {
   object[OWNER] = owner;
 }
 


### PR DESCRIPTION
See https://blog.mariusschulz.com/2017/02/24/typescript-2-2-the-object-type
for an overview of the difference.