### PR TITLE
remove array destructuring

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -97,7 +97,7 @@ export default class Registry implements RegistryAccessor {
   registeredOptions(specifier: string): any {
     let options = this._registeredOptions[specifier];
     if (options === undefined) {
-      let [type] = specifier.split(':');
+      let type = specifier.split(':')[0];
       options = this._registeredOptions[type];
     }
     return options;
@@ -123,7 +123,7 @@ export default class Registry implements RegistryAccessor {
   }
 
   registeredInjections(specifier: string): Injection[] {
-    let [type] = specifier.split(':');
+    let type = specifier.split(':')[0];
     let injections: Injection[] = this._fallback ? this._fallback.registeredInjections(specifier) : [];
     Array.prototype.push.apply(injections, this._registeredInjections[type]);
     Array.prototype.push.apply(injections, this._registeredInjections[specifier]);

--- a/src/specifier.ts
+++ b/src/specifier.ts
@@ -7,7 +7,9 @@ export interface Specifier {
 }
 
 export function isSpecifierStringAbsolute(specifier: string): boolean {
-  let [type, path] = specifier.split(':');
+  let split = specifier.split(':');
+  let type = split[0];
+  let path = split[1];
   return !!(type && path && path.indexOf('/') === 0 && path.split('/').length > 3);
 }
 
@@ -57,7 +59,9 @@ export function deserializeSpecifier(specifier: string): Specifier {
   let obj: Specifier = {};
 
   if (specifier.indexOf(':') > -1) {
-    let [type, path] = specifier.split(':');
+    let split  = specifier.split(':');
+    let type = split[0];
+    let path = split[1];
     obj.type = type;
 
     let pathSegments;


### PR DESCRIPTION
The compiler does not infer that this is an array, so it must assume it to also be an iterator. The resulting code is inefficient and bloated.

able to infer:

```js
let [x] = [1]; // locally statically  infer RHS is an array;
```

Can't infer:

```js
let [x] = someMethodCall(); 
let [x] = someArgument;
let [x] = someGlobal;
let [x] = some.property;
```

In each occurrence:

```js
var _specifier$split = specifier.split(':'),
      _specifier$split2 = slicedToArray(_specifier$split, 1),
      type = _specifier$split2[0];
```

babel helper:
```js
var slicedToArray = function () {
  function sliceIterator(arr, i) {
    var _arr = [];
    var _n = true;
    var _d = false;
    var _e = undefined;

    try {
      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
        _arr.push(_s.value);

        if (i && _arr.length === i) break;
      }
    } catch (err) {
      _d = true;
      _e = err;
    } finally {
      try {
        if (!_n && _i["return"]) _i["return"]();
      } finally {
        if (_d) throw _e;
      }
    }

    return _arr;
  }

  return function (arr, i) {
    if (Array.isArray(arr)) {
      return arr;
    } else if (Symbol.iterator in Object(arr)) {
      return sliceIterator(arr, i);
    } else {
      throw new TypeError("Invalid attempt to destructure non-iterable instance");
    }
  };
}();
```

It may also be possible to disable support for iterables all together, resulting in a more reasonable output.