### PR TITLE
Fix specifier with scoped rootName

### DIFF
--- a/src/specifier.ts
+++ b/src/specifier.ts
@@ -68,7 +68,11 @@ export function deserializeSpecifier(specifier: string): Specifier {
 
     if (path.indexOf('/') === 0) {
       pathSegments = path.substr(1).split('/');
-      obj.rootName = pathSegments.shift();
+      if (path.substr(1).startsWith('@')) {
+        obj.rootName = pathSegments.shift() + '/' + pathSegments.shift();
+      } else {
+        obj.rootName = pathSegments.shift();
+      }
       obj.collection = pathSegments.shift();
     } else {
       pathSegments = path.split('/');

--- a/test/specifier-test.ts
+++ b/test/specifier-test.ts
@@ -86,7 +86,7 @@ test('#serializeSpecifier - serializes a Specifier object without a namespace', 
   assert.equal(serializeSpecifier(a), 'component:/app/components/slick-input');
 });
 
-test('#serializeSpecifier - serializes a specificer object with a scoped rootName', function (assert) {
+test('#serializeSpecifier - serializes a Specifier object with a scoped rootName', function (assert) {
   let a: Specifier = {
     rootName: '@scoped/pkg-name',
     collection: 'components',
@@ -129,7 +129,7 @@ test('#deserializeSpecifier - deserializes a multi-part-namespace specifier stri
   });
 });
 
-test('#deserializeSpecifier - deserialies a scoped rootName specifier string into a Serializer object', function (assert) {
+test('#deserializeSpecifier - deserializes a scoped rootName specifier string into a Serializer object', function (assert) {
   let a = deserializeSpecifier('component:/@scoped/pkg-name/components/slick-input');
   
   assert.deepEqual(a, {

--- a/test/specifier-test.ts
+++ b/test/specifier-test.ts
@@ -86,6 +86,17 @@ test('#serializeSpecifier - serializes a Specifier object without a namespace', 
   assert.equal(serializeSpecifier(a), 'component:/app/components/slick-input');
 });
 
+test('#serializeSpecifier - serialier a Specificer object with a scoped rootName', function (assert) {
+  let a: Specifier = {
+    rootName: '@scoped/pkg-name',
+    collection: 'components',
+    name: 'slick-input',
+    type: 'component'
+  };
+
+  assert.equal(serializeSpecifier(a), 'component:/@scoped/pkg-name/components/slick-input');
+});
+
 test('#deserializeSpecifier - deserializes a type-only specifier string into a Serializer object', function(assert) {
   let a = deserializeSpecifier('instance-initializer');
 
@@ -113,6 +124,17 @@ test('#deserializeSpecifier - deserializes a multi-part-namespace specifier stri
     rootName: 'app',
     collection: 'components',
     namespace: 'slick-ui/form/inputs',
+    name: 'slick-input',
+    type: 'component'
+  });
+});
+
+test('#deserializeSpecifier - deserialiers a scoped rootName specifier string into a Serializer object', function (assert) {
+  let a = deserializeSpecifier('component:/@scoped/pkg-name/components/slick-input');
+  
+  assert.deepEqual(a, {
+    rootName: '@scoped/pkg-name',
+    collection: 'components',
     name: 'slick-input',
     type: 'component'
   });

--- a/test/specifier-test.ts
+++ b/test/specifier-test.ts
@@ -86,7 +86,7 @@ test('#serializeSpecifier - serializes a Specifier object without a namespace', 
   assert.equal(serializeSpecifier(a), 'component:/app/components/slick-input');
 });
 
-test('#serializeSpecifier - serialier a Specificer object with a scoped rootName', function (assert) {
+test('#serializeSpecifier - serializes a specificer object with a scoped rootName', function (assert) {
   let a: Specifier = {
     rootName: '@scoped/pkg-name',
     collection: 'components',
@@ -129,7 +129,7 @@ test('#deserializeSpecifier - deserializes a multi-part-namespace specifier stri
   });
 });
 
-test('#deserializeSpecifier - deserialiers a scoped rootName specifier string into a Serializer object', function (assert) {
+test('#deserializeSpecifier - deserialies a scoped rootName specifier string into a Serializer object', function (assert) {
   let a = deserializeSpecifier('component:/@scoped/pkg-name/components/slick-input');
   
   assert.deepEqual(a, {


### PR DESCRIPTION
Since npm supports scoped packages, e.g. `@glimmer/*` it wasn't supported with this library. Support is added. I'm wondering, wether this is complete and ready to merge or if I need to add/change something?